### PR TITLE
feat: date component passthrough prop for bad dates

### DIFF
--- a/__tests__/Date.test.tsx
+++ b/__tests__/Date.test.tsx
@@ -14,7 +14,11 @@ cases(
   "Date Formatter",
   opts => {
     const wrapper = mount(
-      <DateComponent locale={opts.locale} options={opts.options}>
+      <DateComponent
+        locale={opts.locale}
+        options={opts.options}
+        passthrough={opts.passthrough}
+      >
         {opts.date}
       </DateComponent>
     );
@@ -63,6 +67,11 @@ cases(
         second: "2-digit",
         timeZoneName: "long"
       }
+    },
+    {
+      name: "passthrough works",
+      date: "badDate",
+      passthrough: true
     }
   ]
 );

--- a/__tests__/__snapshots__/Date.test.tsx.snap
+++ b/__tests__/__snapshots__/Date.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`Date Formatter Bad Date passed in 1`] = `
 <Component
   locale="en-US"
   options={Object {}}
+  passthrough={false}
 >
   <span />
 </Component>
@@ -13,6 +14,7 @@ exports[`Date Formatter does basic formatting of a date string- without config 1
 <Component
   locale="en-US"
   options={Object {}}
+  passthrough={false}
 >
   <span>
     3/25/2015
@@ -24,6 +26,7 @@ exports[`Date Formatter does basic formatting of a date- without config 1`] = `
 <Component
   locale="en-US"
   options={Object {}}
+  passthrough={false}
 >
   <span>
     12/19/2012
@@ -39,6 +42,7 @@ exports[`Date Formatter does basic formatting of a zero date string with UTC opt
       "timeZone": "UTC",
     }
   }
+  passthrough={false}
 >
   <span>
     3/1/2015
@@ -50,6 +54,7 @@ exports[`Date Formatter does basic formatting of a zero date string without UTC 
 <Component
   locale="en-US"
   options={Object {}}
+  passthrough={false}
 >
   <span>
     2/28/2015
@@ -61,9 +66,22 @@ exports[`Date Formatter is responsive to locale changes 1`] = `
 <Component
   locale="de-DE"
   options={Object {}}
+  passthrough={false}
 >
   <span>
     19.12.2012
+  </span>
+</Component>
+`;
+
+exports[`Date Formatter passthrough works 1`] = `
+<Component
+  locale="en-US"
+  options={Object {}}
+  passthrough={true}
+>
+  <span>
+    badDate
   </span>
 </Component>
 `;
@@ -85,6 +103,7 @@ exports[`Date Formatter takes and applies an options prop 1`] = `
       "year": "2-digit",
     }
   }
+  passthrough={false}
 >
   <span>
     Wednesday, December 19, 12 Anno Domini, 10:00:00 PM Eastern Standard Time

--- a/src/Date.tsx
+++ b/src/Date.tsx
@@ -18,6 +18,7 @@ export interface IDateProps {
     timeZoneName?: "short" | "long";
   };
   children: any;
+  passthrough?: boolean;
 }
 
 const validDate = (potentialDate: any): boolean =>
@@ -29,10 +30,17 @@ const formatDate = (props: IDateProps): string =>
   );
 
 export const DateFormatter: React.SFC<IDateProps> = (props): JSX.Element => (
-  <span>{validDate(props.children) && formatDate(props)}</span>
+  <span>
+    {validDate(props.children) ? (
+      formatDate(props)
+    ) : (
+      props.passthrough && props.children
+    )}
+  </span>
 );
 
 DateFormatter.defaultProps = {
   locale: "en-US",
-  options: {}
+  options: {},
+  passthrough: false
 };


### PR DESCRIPTION
Proposal for a prop (passthrough) to be added that would change the behavior of the render when a 'bad' (invalid) date is provided. Currently the component renders nothing when that happens but this prop (passthrough) would make it so that the component would render out the invalid date directly instead of rendering nothing.

https://github.com/divyagnan/react-format/blob/243339024340cf7719a4e61fd5e0d6b6cb2a710d/src/Date.tsx#L32-L40

example

```jsx
<Date>"invalid date string"</Date> // renders <span />

<Date passthrough>"invalid date string"</Date> // renders <span>"invalid date string"</span>
```

Undecided about adding this (and undecided about the naming as well).